### PR TITLE
fix: getReactedCopy() result will have content if argument has content

### DIFF
--- a/src/store/documentStore.ts
+++ b/src/store/documentStore.ts
@@ -126,7 +126,11 @@ export class DocumentStore {
         if (node.attrs) {
             const { [this.idAttrKey]: nodeId } = node.attrs;
             if (this.nodeStores[nodeId]) {
-                return this.availableNodes[nodeId];
+                const reactedCopy = this.availableNodes[nodeId];
+                if (node.content) {
+                    return reactedCopy.copy(node.content);
+                }
+                return reactedCopy;
             }
         }
         return null;


### PR DESCRIPTION
Now that we have some nodes (`tables`) that are reactive and also have content, `getReactedCopy(node)` should return a reacted copy of `node` with its contents intact.

_Test plan:_
I loaded up PubPub with these changes and verified that tables export and SSR correctly.