### PR TITLE
fix: Also delegate NodeViews that come from plugins

### DIFF
--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -67,7 +67,10 @@ export const createReactivePlugin = ({ idAttrKey, schema, documentState = {} }: 
             editorView = view;
             editorView.update({
                 ...view.props,
-                nodeViews: createReactiveNodeViews(view, schema, store),
+                nodeViews: {
+                    ...view.props.nodeViews,
+                    ...createReactiveNodeViews(view, schema, store),
+                },
             });
             return {
                 update: nextView => {


### PR DESCRIPTION
The reactive plugin works by assigning `NodeViews` to node types with `reactive: true`, but if those node types already have a correspond NodeView, we want to delegate to its behavior instead of clobbering it. Some of these NodeViews will be exposed through a plugin rather than directly through `editorView.props.nodeViews`, so we need to check those too.

_Test plan:_
I wired this up to PubPub and verified that it correctly delegates to the `prosemirror-tables` plugin.